### PR TITLE
Strict comparison added to in_array usage in triggerBeforeFind.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -18,7 +18,7 @@ class Query extends CakeQuery
             $aliasedField = $this
                 ->getRepository()
                 ->aliasField($this->getRepository()->getSoftDeleteField());
-            if (!is_array($this->getOptions()) || !in_array('withDeleted', $this->getOptions())) {
+            if (!is_array($this->getOptions()) || !in_array('withDeleted', $this->getOptions(),true)) {
                 $this->andWhere($aliasedField . ' IS NULL');
             }
         }


### PR DESCRIPTION
Resolves issue of deleted constraint not being added to query when a zero is present in the query options as a value.
See https://bugs.php.net/bug.php?id=68830
